### PR TITLE
[BE] feat: google api key , build.gradle 의존성 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 
     /* postgresql */
     implementation 'org.postgresql:postgresql'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     runtimeOnly 'org.postgresql:postgresql'
 
     /* lombok */

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -39,3 +39,10 @@ oauth:
     secret: ${NAVER_SECRET}
     token-uri: https://nid.naver.com/oauth2.0/token
     user-info-uri: https://openapi.naver.com/v1/nid/me
+  google:
+    redirect: ${GOOGLE_REDIRECT_URI}
+    client: ${GOOGLE_CLIENT}
+    secret: ${GOOGLE_SECRET}
+    token-uri: https://oauth2.googleapis.com/token
+    user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
+    # authorization-uri: https://accounts.google.com/o/oauth2/v2/auth


### PR DESCRIPTION
## #️⃣ 관련 이슈
#4 
<br/>
## 🔎개요
application.yml에 google api key 추가
build.gradle oauth2
<br/>
## :메모:작업 내용
GOOGLE api -> client-id, client-secret, redirectUri 환경변수화 및 token, user-info uri 정의 (application.yml)
build.gradle oauth2 의존성 추가
<br/>