### PR TITLE
[BE] bug: ExtendedUserDetailsService Bean define 에러 버그 수정

### DIFF
--- a/backend/src/main/java/com/ballx/security/ExtendedUserDetailsServiceImpl.java
+++ b/backend/src/main/java/com/ballx/security/ExtendedUserDetailsServiceImpl.java
@@ -5,12 +5,16 @@ import com.ballx.service.user.UserService;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.context.annotation.Primary;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
 
 import java.util.Optional;
 import java.util.UUID;
 
+@Service
+@Primary
 @RequiredArgsConstructor
 public class ExtendedUserDetailsServiceImpl implements ExtendedUserDetailsService {
 


### PR DESCRIPTION
<!-- 제목 예시: [BE & FE] or be fe 공통작업은 [Common] feat: 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#30 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
- ExtendedUserDetailsService 빈등록 (@Service) 및 @Primary 우선순위 조정
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->

- ExtendedUserDetailsService 빈등록 (@Service) 및 @Primary 우선순위 조정
- SecurityConfiguration 에 @Bean 하는 방법 중 현재 방법이 더 명확하고 객체 지향적 설계와 단일 책임 원칙에 더 부합하여 이 방법을 택함

<br/>