### PR TITLE
[BE] feat: 계정등록 시 인증번호 전송 (Sms 전송) Service 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -57,6 +57,10 @@ dependencies {
     /* Sms nurigo */
     implementation 'net.nurigo:sdk:4.3.2'
 
+    /* Redis */
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.32.0'
+
     /* JSON Logging (OTel 연동용) */
     implementation 'net.logstash.logback:logstash-logback-encoder:8.0'
 

--- a/backend/src/main/java/com/ballx/config/redis/RedisConfig.java
+++ b/backend/src/main/java/com/ballx/config/redis/RedisConfig.java
@@ -1,0 +1,57 @@
+package com.ballx.config.redis;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import lombok.RequiredArgsConstructor;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+
+	private final RedisProperties redisProperties;
+
+	@Bean
+	public RedissonClient localRedissonClient() {
+		var config = new Config();
+		var host = redisProperties.getCluster().getNodes().getFirst();
+		var uri = String.format("redis://%s", host);
+
+		config.useSingleServer().setAddress(uri);
+		return Redisson.create(config);
+	}
+
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory factory) {
+		RedisTemplate<String, Object> template = new RedisTemplate<>();
+		template.setConnectionFactory(factory);
+
+		template.setKeySerializer(new StringRedisSerializer());
+		template.setHashKeySerializer(new StringRedisSerializer());
+
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.registerModule(new JavaTimeModule());
+		objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+		GenericJackson2JsonRedisSerializer serializer =
+			new GenericJackson2JsonRedisSerializer(objectMapper);
+
+		template.setValueSerializer(serializer);
+		template.setHashValueSerializer(serializer);
+
+		template.afterPropertiesSet();
+		return template;
+	}
+}

--- a/backend/src/main/java/com/ballx/config/validator/MobileValidator.java
+++ b/backend/src/main/java/com/ballx/config/validator/MobileValidator.java
@@ -1,0 +1,27 @@
+package com.ballx.config.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class MobileValidator implements ConstraintValidator<ValidMobile, String> {
+
+	final static int MOBILE_LENGTH = 11;
+	final static String MOBILE_PREFIX = "010";
+
+	@Override
+	public boolean isValid(String value, ConstraintValidatorContext context) {
+		if (value.length() != MOBILE_LENGTH || !value.startsWith(MOBILE_PREFIX)) {
+			return false;
+		}
+
+		String body = value.substring(3);
+
+		for (char c : body.toCharArray()) {
+			if (!Character.isDigit(c)) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+}

--- a/backend/src/main/java/com/ballx/config/validator/ValidMobile.java
+++ b/backend/src/main/java/com/ballx/config/validator/ValidMobile.java
@@ -1,0 +1,23 @@
+package com.ballx.config.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Constraint(validatedBy = MobileValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidMobile {
+
+	String message() default "휴대폰 번호 형식이 올바르지 않습니다.";
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+}

--- a/backend/src/main/java/com/ballx/config/validator/ValidMobile.java
+++ b/backend/src/main/java/com/ballx/config/validator/ValidMobile.java
@@ -15,7 +15,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ValidMobile {
 
-	String message() default "휴대폰 번호 형식이 올바르지 않습니다.";
+	String message() default "휴대전화 번호 형식이 올바르지 않습니다.";
 
 	Class<?>[] groups() default {};
 

--- a/backend/src/main/java/com/ballx/constants/redis/RedisKey.java
+++ b/backend/src/main/java/com/ballx/constants/redis/RedisKey.java
@@ -1,0 +1,20 @@
+package com.ballx.constants.redis;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.Duration;
+
+@Getter
+@RequiredArgsConstructor
+public enum RedisKey {
+	AUTH_CODE("auth:code:", Duration.ofMinutes(3));
+
+	private final String prefix;
+
+	private final Duration ttl;
+
+	public String getKey(Object val) {
+		return prefix + val;
+	}
+}

--- a/backend/src/main/java/com/ballx/domain/dto/request/AuthCodeRequest.java
+++ b/backend/src/main/java/com/ballx/domain/dto/request/AuthCodeRequest.java
@@ -1,0 +1,12 @@
+package com.ballx.domain.dto.request;
+
+import com.ballx.config.validator.ValidMobile;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AuthCodeRequest(
+	@NotBlank(message = "휴대폰 번호는 필수 항목입니다.")
+	@ValidMobile
+	String mobile
+) {
+}

--- a/backend/src/main/java/com/ballx/domain/dto/request/AuthCodeRequest.java
+++ b/backend/src/main/java/com/ballx/domain/dto/request/AuthCodeRequest.java
@@ -5,7 +5,7 @@ import com.ballx.config.validator.ValidMobile;
 import jakarta.validation.constraints.NotBlank;
 
 public record AuthCodeRequest(
-	@NotBlank(message = "휴대폰 번호는 필수 항목입니다.")
+	@NotBlank(message = "휴대전화 번호는 필수 항목입니다.")
 	@ValidMobile
 	String mobile
 ) {

--- a/backend/src/main/java/com/ballx/infra/cache/RedisCache.java
+++ b/backend/src/main/java/com/ballx/infra/cache/RedisCache.java
@@ -1,0 +1,42 @@
+package com.ballx.infra.cache;
+
+import com.ballx.constants.redis.RedisKey;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class RedisCache {
+	private final RedisTemplate<String, Object> redisTemplate;
+
+	public <T> void set(String key, T value) {
+		redisTemplate.opsForValue().set(key, value);
+	}
+
+	public <T> void set(String key, T value, Duration ttl) {
+		redisTemplate.opsForValue().set(key, value, ttl.toMillis(), TimeUnit.MILLISECONDS);
+	}
+
+	public <T> void set(RedisKey redisKey, Object keyParam, T value) {
+		set(redisKey.getKey(keyParam), value, redisKey.getTtl());
+	}
+
+	public <T> T get(String key, Class<T> clazz) {
+		Object value = redisTemplate.opsForValue().get(key);
+		return value != null ? clazz.cast(value) : null;
+	}
+
+	public void delete(String key) {
+		redisTemplate.delete(key);
+	}
+
+	public boolean hasKey(String key) {
+		return redisTemplate.hasKey(key);
+	}
+}

--- a/backend/src/main/java/com/ballx/service/auth/AuthService.java
+++ b/backend/src/main/java/com/ballx/service/auth/AuthService.java
@@ -1,0 +1,6 @@
+package com.ballx.service.auth;
+
+public interface AuthService {
+
+	void sendAuthCode(String mobile);
+}

--- a/backend/src/main/java/com/ballx/service/auth/AuthServiceImpl.java
+++ b/backend/src/main/java/com/ballx/service/auth/AuthServiceImpl.java
@@ -1,0 +1,31 @@
+package com.ballx.service.auth;
+
+import com.ballx.constants.redis.RedisKey;
+import com.ballx.infra.cache.RedisCache;
+import com.ballx.infra.sms.SmsProvider;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+
+	private final SmsProvider smsProvider;
+	private final RedisCache redisCache;
+
+	@Override
+	public void sendAuthCode(String mobile) {
+		String authCode = getAuthenticationCode();
+		smsProvider.send(mobile, authCode);
+		redisCache.set(RedisKey.AUTH_CODE, mobile, authCode);
+	}
+
+	private String getAuthenticationCode() {
+		int code = new Random().nextInt(900000) + 100000;
+		return String.valueOf(code);
+	}
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -28,6 +28,13 @@ spring:
   jackson:
     time-zone: Asia/Seoul
     date-format: yyyy-MM-dd'T'HH:mm:ss.SSSXXX
+  data:
+    redis:
+      ssl:
+        enabled: true
+      cluster:
+        nodes: ${REDIS_HOST}
+        max-redirects: 3
 
 # OTel 연동을 위한 JSON 로깅 설정 (Spring Boot 3.4+)
 logging:

--- a/backend/src/test/java/com/ballx/infra/sms/SmsProviderTest.java
+++ b/backend/src/test/java/com/ballx/infra/sms/SmsProviderTest.java
@@ -33,7 +33,7 @@ class SmsProviderTest {
 
 		SmsProvider smsProvider = new SmsProvider(smsProperties, defaultMessageService);
 
-		String receiver = "{Receiver}"; // 필요 시 받는 이 휴대폰번호 정확히 기입 후 테스트 진행
+		String receiver = "{Receiver}"; // 필요 시 받는 이 휴대전화 번호 정확히 기입 후 테스트 진행
 
 		smsProvider.send(receiver, "123123");
 

--- a/backend/src/test/java/com/ballx/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/ballx/service/AuthServiceTest.java
@@ -1,0 +1,39 @@
+package com.ballx.service;
+
+import com.ballx.constants.redis.RedisKey;
+import com.ballx.infra.cache.RedisCache;
+import com.ballx.service.auth.AuthService;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@Slf4j
+@ActiveProfiles("test")
+@SpringBootTest
+public class AuthServiceTest {
+
+	@Autowired
+	AuthService authService;
+
+	@Autowired
+	RedisCache redisCache;
+
+	final static String MOBILE = "01043053451";
+
+	@Test
+	@Disabled("비용 발생으로 테스트 시 Disabled 주석 처리 후 테스트 진행")
+	void 휴대폰_인증번호_전송_redis_저장() {
+		authService.sendAuthCode(MOBILE);
+		String authCode = redisCache.get(RedisKey.AUTH_CODE.getKey(MOBILE), String.class);
+		assertNotNull(authCode);
+		log.info("authCode :: {}", authCode);
+	}
+
+}

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -1,23 +1,7 @@
 spring:
-  test:
-    database:
-      replace: none
-
-  datasource:
-    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
-
+  config:
+    import:
+      - optional:file:.env.test[.properties]
   jpa:
     hibernate:
       ddl-auto: create-drop
-    database-platform: org.hibernate.dialect.PostgreSQLDialect
-    show-sql: true
-    properties:
-      hibernate:
-        format_sql: true
-  h2:
-    console:
-      path: /h2-console
-      enabled: true


### PR DESCRIPTION
<!-- 제목 예시: [BE & FE] or be fe 공통작업은 [Common] feat: 유저 회원가입 서비스 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## #️⃣ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#36 
<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
- 계정등록(회원가입 및 로그인) 시 인증번호 (SMS) 전송 서비스 구현
- SMS 전송 서비스 테스트
<br/>


## 📋 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- 회원가입 시 인증번호 (SMS) 전송 서비스 구현(AuthService)
- NurigoApp initialize 정의 추가 및 의존성 추가(in build.gradle)
- SMS 전송 서비스 테스트 추가 (disabled 내용 (주석참고) 추가)
- ValidMobile CustomAnnotation 추가
- Redis 정의 파일 추가 및 RedisCache 접근 모듈 생성
- RedisKey (Redis 키 모음 파일) 생성
- application-test.yml 파일 수정 (application.yml Import 및 중복되는 태그 -> overrite)
<br/>